### PR TITLE
chore: add test coverage with pytest-cov

### DIFF
--- a/.github/workflows/ci_cd_wf.yml
+++ b/.github/workflows/ci_cd_wf.yml
@@ -26,4 +26,4 @@ jobs:
           python -m pip install -r requirements.txt
       - name: Run tests
         run: |
-          python -m pytest -v tests
+          python -m pytest --cov=./tests             

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,9 @@
 colorama==0.4.6
-exceptiongroup==1.1.1
+coverage==7.3.2
+exceptiongroup==1.1.3
 iniconfig==2.0.0
-packaging==23.1
-pluggy==1.0.0
-pytest==7.3.1
+packaging==23.2
+pluggy==1.3.0
+pytest==7.4.3
+pytest-cov==4.1.0
 tomli==2.0.1


### PR DESCRIPTION
- Added `pytest-cov` to be able to display code coverage for CI builds.